### PR TITLE
Add stored procedure name accessor and tests

### DIFF
--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java
@@ -29,10 +29,9 @@ public abstract class DbClientSpanNameExtractor<REQUEST> implements SpanNameExtr
    * Returns a {@link SpanNameExtractor} that constructs the span name according to DB semantic
    * conventions: {@code <db.operation> <db.name>.<identifier>}.
    *
-   * @see SqlStatementInfo#getOperation() used to extract {@code <db.operation>}.
+   * @see SqlStatementInfo#getOperationName() used to extract {@code <db.operation.name>}.
    * @see DbClientAttributesGetter#getDbNamespace(Object) used to extract {@code <db.namespace>}.
-   * @see SqlStatementInfo#getMainIdentifier() used to extract {@code <db.table>} or stored
-   *     procedure name.
+   * @see SqlStatementInfo#getTarget() used to extract {@code <db.table>} or stored procedure name.
    */
   public static <REQUEST> SpanNameExtractor<REQUEST> create(
       SqlClientAttributesGetter<REQUEST, ?> getter) {
@@ -108,24 +107,24 @@ public abstract class DbClientSpanNameExtractor<REQUEST> implements SpanNameExtr
         SqlStatementInfo sanitizedStatement =
             SqlStatementSanitizerUtil.sanitize(rawQueryTexts.iterator().next());
         return computeSpanName(
-            namespace, sanitizedStatement.getOperation(), sanitizedStatement.getMainIdentifier());
+            namespace, sanitizedStatement.getOperationName(), sanitizedStatement.getTarget());
       }
 
       if (rawQueryTexts.size() == 1) {
         SqlStatementInfo sanitizedStatement =
             SqlStatementSanitizerUtil.sanitize(rawQueryTexts.iterator().next());
-        String operation = sanitizedStatement.getOperation();
+        String operation = sanitizedStatement.getOperationName();
         if (isBatch(request)) {
           operation = "BATCH " + operation;
         }
-        return computeSpanName(namespace, operation, sanitizedStatement.getMainIdentifier());
+        return computeSpanName(namespace, operation, sanitizedStatement.getTarget());
       }
 
       MultiQuery multiQuery = MultiQuery.analyze(rawQueryTexts, false);
       return computeSpanName(
           namespace,
-          multiQuery.getOperation() != null ? "BATCH " + multiQuery.getOperation() : "BATCH",
-          multiQuery.getMainIdentifier());
+          multiQuery.getOperationName() != null ? "BATCH " + multiQuery.getOperationName() : "BATCH",
+          multiQuery.getTarget());
     }
 
     private boolean isBatch(REQUEST request) {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/DbClientSpanNameExtractor.java
@@ -123,7 +123,9 @@ public abstract class DbClientSpanNameExtractor<REQUEST> implements SpanNameExtr
       MultiQuery multiQuery = MultiQuery.analyze(rawQueryTexts, false);
       return computeSpanName(
           namespace,
-          multiQuery.getOperationName() != null ? "BATCH " + multiQuery.getOperationName() : "BATCH",
+          multiQuery.getOperationName() != null
+              ? "BATCH " + multiQuery.getOperationName()
+              : "BATCH",
           multiQuery.getTarget());
     }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
@@ -12,26 +12,34 @@ import javax.annotation.Nullable;
 
 class MultiQuery {
 
-  @Nullable private final String target;
+  @Nullable private final String collectionName;
+  @Nullable private final String storedProcedureName;
   @Nullable private final String operationName;
   private final Set<String> statements;
 
   private MultiQuery(
-      @Nullable String target, @Nullable String operationName, Set<String> statements) {
-    this.target = target;
+      @Nullable String collectionName,
+      @Nullable String storedProcedureName,
+      @Nullable String operationName,
+      Set<String> statements) {
+    this.collectionName = collectionName;
+    this.storedProcedureName = storedProcedureName;
     this.operationName = operationName;
     this.statements = statements;
   }
 
   static MultiQuery analyze(
       Collection<String> rawQueryTexts, boolean statementSanitizationEnabled) {
-    UniqueValue uniqueTarget = new UniqueValue();
+    UniqueValue uniqueCollectionName = new UniqueValue();
+    UniqueValue uniqueStoredProcedureName = new UniqueValue();
     UniqueValue uniqueOperationName = new UniqueValue();
     Set<String> uniqueStatements = new LinkedHashSet<>();
     for (String rawQueryText : rawQueryTexts) {
       SqlStatementInfo sanitizedStatement = SqlStatementSanitizerUtil.sanitize(rawQueryText);
-      String target = sanitizedStatement.getTarget();
-      uniqueTarget.set(target);
+      String collectionName = sanitizedStatement.getCollectionName();
+      uniqueCollectionName.set(collectionName);
+      String storedProcedureName = sanitizedStatement.getStoredProcedureName();
+      uniqueStoredProcedureName.set(storedProcedureName);
       String operationName = sanitizedStatement.getOperationName();
       uniqueOperationName.set(operationName);
       uniqueStatements.add(
@@ -39,12 +47,25 @@ class MultiQuery {
     }
 
     return new MultiQuery(
-        uniqueTarget.getValue(), uniqueOperationName.getValue(), uniqueStatements);
+        uniqueCollectionName.getValue(),
+        uniqueStoredProcedureName.getValue(),
+        uniqueOperationName.getValue(),
+        uniqueStatements);
+  }
+
+  @Nullable
+  public String getCollectionName() {
+    return collectionName;
+  }
+
+  @Nullable
+  public String getStoredProcedureName() {
+    return storedProcedureName;
   }
 
   @Nullable
   public String getTarget() {
-    return target;
+    return collectionName != null ? collectionName : storedProcedureName;
   }
 
   /**

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/MultiQuery.java
@@ -12,44 +12,62 @@ import javax.annotation.Nullable;
 
 class MultiQuery {
 
-  @Nullable private final String mainIdentifier;
-  @Nullable private final String operation;
+  @Nullable private final String target;
+  @Nullable private final String operationName;
   private final Set<String> statements;
 
   private MultiQuery(
-      @Nullable String mainIdentifier, @Nullable String operation, Set<String> statements) {
-    this.mainIdentifier = mainIdentifier;
-    this.operation = operation;
+      @Nullable String target, @Nullable String operationName, Set<String> statements) {
+    this.target = target;
+    this.operationName = operationName;
     this.statements = statements;
   }
 
   static MultiQuery analyze(
       Collection<String> rawQueryTexts, boolean statementSanitizationEnabled) {
-    UniqueValue uniqueMainIdentifier = new UniqueValue();
-    UniqueValue uniqueOperation = new UniqueValue();
+    UniqueValue uniqueTarget = new UniqueValue();
+    UniqueValue uniqueOperationName = new UniqueValue();
     Set<String> uniqueStatements = new LinkedHashSet<>();
     for (String rawQueryText : rawQueryTexts) {
       SqlStatementInfo sanitizedStatement = SqlStatementSanitizerUtil.sanitize(rawQueryText);
-      String mainIdentifier = sanitizedStatement.getMainIdentifier();
-      uniqueMainIdentifier.set(mainIdentifier);
-      String operation = sanitizedStatement.getOperation();
-      uniqueOperation.set(operation);
+      String target = sanitizedStatement.getTarget();
+      uniqueTarget.set(target);
+      String operationName = sanitizedStatement.getOperationName();
+      uniqueOperationName.set(operationName);
       uniqueStatements.add(
-          statementSanitizationEnabled ? sanitizedStatement.getFullStatement() : rawQueryText);
+          statementSanitizationEnabled ? sanitizedStatement.getQueryText() : rawQueryText);
     }
 
     return new MultiQuery(
-        uniqueMainIdentifier.getValue(), uniqueOperation.getValue(), uniqueStatements);
+        uniqueTarget.getValue(), uniqueOperationName.getValue(), uniqueStatements);
   }
 
+  @Nullable
+  public String getTarget() {
+    return target;
+  }
+
+  /**
+   * @deprecated Use {@link #getTarget()} instead.
+   */
+  @Deprecated
   @Nullable
   public String getMainIdentifier() {
-    return mainIdentifier;
+    return getTarget();
   }
 
   @Nullable
+  public String getOperationName() {
+    return operationName;
+  }
+
+  /**
+   * @deprecated Use {@link #getOperationName()} instead.
+   */
+  @Deprecated
+  @Nullable
   public String getOperation() {
-    return operation;
+    return getOperationName();
   }
 
   public Set<String> getStatements() {

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.semconv.DbAttributes.DB_COLLECTION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_BATCH_SIZE;
 import static io.opentelemetry.semconv.DbAttributes.DB_OPERATION_NAME;
 import static io.opentelemetry.semconv.DbAttributes.DB_QUERY_TEXT;
+import static io.opentelemetry.semconv.DbAttributes.DB_STORED_PROCEDURE_NAME;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -119,9 +120,9 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
             DB_QUERY_TEXT,
             statementSanitizationEnabled ? sanitizedStatement.getQueryText() : rawQueryText);
         internalSet(attributes, DB_OPERATION_NAME, isBatch ? "BATCH " + operation : operation);
-        if (!SQL_CALL.equals(operation)) {
-          internalSet(attributes, DB_COLLECTION_NAME, sanitizedStatement.getTarget());
-        }
+        internalSet(attributes, DB_COLLECTION_NAME, sanitizedStatement.getCollectionName());
+        internalSet(
+            attributes, DB_STORED_PROCEDURE_NAME, sanitizedStatement.getStoredProcedureName());
       } else if (rawQueryTexts.size() > 1) {
         MultiQuery multiQuery =
             MultiQuery.analyze(getter.getRawQueryTexts(request), statementSanitizationEnabled);
@@ -133,11 +134,9 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
                 : "BATCH";
         internalSet(attributes, DB_OPERATION_NAME, operation);
 
-        if (multiQuery.getTarget() != null
-            && (multiQuery.getOperationName() == null
-                || !SQL_CALL.equals(multiQuery.getOperationName()))) {
-          internalSet(attributes, DB_COLLECTION_NAME, multiQuery.getTarget());
-        }
+        internalSet(attributes, DB_COLLECTION_NAME, multiQuery.getCollectionName());
+        internalSet(attributes, DB_STORED_PROCEDURE_NAME, multiQuery.getStoredProcedureName());
+>>>>>>> 77ccea1940 (Add stored procedure name accessor and tests)
       }
     }
 

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -128,11 +128,14 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
         internalSet(attributes, DB_QUERY_TEXT, join("; ", multiQuery.getStatements()));
 
         String operation =
-            multiQuery.getOperationName() != null ? "BATCH " + multiQuery.getOperationName() : "BATCH";
+            multiQuery.getOperationName() != null
+                ? "BATCH " + multiQuery.getOperationName()
+                : "BATCH";
         internalSet(attributes, DB_OPERATION_NAME, operation);
 
         if (multiQuery.getTarget() != null
-            && (multiQuery.getOperationName() == null || !SQL_CALL.equals(multiQuery.getOperationName()))) {
+            && (multiQuery.getOperationName() == null
+                || !SQL_CALL.equals(multiQuery.getOperationName()))) {
           internalSet(attributes, DB_COLLECTION_NAME, multiQuery.getTarget());
         }
       }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlClientAttributesExtractor.java
@@ -94,14 +94,14 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
       if (rawQueryTexts.size() == 1) { // for backcompat(?)
         String rawQueryText = rawQueryTexts.iterator().next();
         SqlStatementInfo sanitizedStatement = SqlStatementSanitizerUtil.sanitize(rawQueryText);
-        String operation = sanitizedStatement.getOperation();
+        String operation = sanitizedStatement.getOperationName();
         internalSet(
             attributes,
             DB_STATEMENT,
-            statementSanitizationEnabled ? sanitizedStatement.getFullStatement() : rawQueryText);
+            statementSanitizationEnabled ? sanitizedStatement.getQueryText() : rawQueryText);
         internalSet(attributes, DB_OPERATION, operation);
         if (!SQL_CALL.equals(operation)) {
-          internalSet(attributes, oldSemconvTableAttribute, sanitizedStatement.getMainIdentifier());
+          internalSet(attributes, oldSemconvTableAttribute, sanitizedStatement.getTarget());
         }
       }
     }
@@ -113,14 +113,14 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
       if (rawQueryTexts.size() == 1) {
         String rawQueryText = rawQueryTexts.iterator().next();
         SqlStatementInfo sanitizedStatement = SqlStatementSanitizerUtil.sanitize(rawQueryText);
-        String operation = sanitizedStatement.getOperation();
+        String operation = sanitizedStatement.getOperationName();
         internalSet(
             attributes,
             DB_QUERY_TEXT,
-            statementSanitizationEnabled ? sanitizedStatement.getFullStatement() : rawQueryText);
+            statementSanitizationEnabled ? sanitizedStatement.getQueryText() : rawQueryText);
         internalSet(attributes, DB_OPERATION_NAME, isBatch ? "BATCH " + operation : operation);
         if (!SQL_CALL.equals(operation)) {
-          internalSet(attributes, DB_COLLECTION_NAME, sanitizedStatement.getMainIdentifier());
+          internalSet(attributes, DB_COLLECTION_NAME, sanitizedStatement.getTarget());
         }
       } else if (rawQueryTexts.size() > 1) {
         MultiQuery multiQuery =
@@ -128,12 +128,12 @@ public final class SqlClientAttributesExtractor<REQUEST, RESPONSE>
         internalSet(attributes, DB_QUERY_TEXT, join("; ", multiQuery.getStatements()));
 
         String operation =
-            multiQuery.getOperation() != null ? "BATCH " + multiQuery.getOperation() : "BATCH";
+            multiQuery.getOperationName() != null ? "BATCH " + multiQuery.getOperationName() : "BATCH";
         internalSet(attributes, DB_OPERATION_NAME, operation);
 
-        if (multiQuery.getMainIdentifier() != null
-            && (multiQuery.getOperation() == null || !SQL_CALL.equals(multiQuery.getOperation()))) {
-          internalSet(attributes, DB_COLLECTION_NAME, multiQuery.getMainIdentifier());
+        if (multiQuery.getTarget() != null
+            && (multiQuery.getOperationName() == null || !SQL_CALL.equals(multiQuery.getOperationName()))) {
+          internalSet(attributes, DB_COLLECTION_NAME, multiQuery.getTarget());
         }
       }
     }

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementInfo.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementInfo.java
@@ -11,8 +11,13 @@ import javax.annotation.Nullable;
 @AutoValue
 public abstract class SqlStatementInfo {
 
+  private static final String SQL_CALL = "CALL";
+
   public static SqlStatementInfo create(
-      @Nullable String queryText, @Nullable String operationName, @Nullable String target) {
+      @Nullable String queryText,
+      @Nullable String operationName,
+      // collectionName and storedProcedureName are compressed into this one field for efficiency
+      @Nullable String target) {
     return new AutoValue_SqlStatementInfo(queryText, operationName, target);
   }
 
@@ -38,6 +43,22 @@ public abstract class SqlStatementInfo {
   @Nullable
   public String getOperation() {
     return getOperationName();
+  }
+
+  /**
+   * Returns the table/collection name, or null for CALL operations.
+   *
+   * @see #getStoredProcedureName()
+   */
+  @Nullable
+  public String getCollectionName() {
+    return SQL_CALL.equals(getOperationName()) ? null : getTarget();
+  }
+
+  /** Returns the stored procedure name for CALL operations, or null for other operations. */
+  @Nullable
+  public String getStoredProcedureName() {
+    return SQL_CALL.equals(getOperationName()) ? getTarget() : null;
   }
 
   @Nullable

--- a/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementInfo.java
+++ b/instrumentation-api-incubator/src/main/java/io/opentelemetry/instrumentation/api/incubator/semconv/db/SqlStatementInfo.java
@@ -12,16 +12,43 @@ import javax.annotation.Nullable;
 public abstract class SqlStatementInfo {
 
   public static SqlStatementInfo create(
-      @Nullable String fullStatement, @Nullable String operation, @Nullable String identifier) {
-    return new AutoValue_SqlStatementInfo(fullStatement, operation, identifier);
+      @Nullable String queryText, @Nullable String operationName, @Nullable String target) {
+    return new AutoValue_SqlStatementInfo(queryText, operationName, target);
   }
 
   @Nullable
-  public abstract String getFullStatement();
+  public abstract String getQueryText();
+
+  /**
+   * @deprecated Use {@link #getQueryText()} instead.
+   */
+  @Deprecated
+  @Nullable
+  public String getFullStatement() {
+    return getQueryText();
+  }
 
   @Nullable
-  public abstract String getOperation();
+  public abstract String getOperationName();
+
+  /**
+   * @deprecated Use {@link #getOperationName()} instead.
+   */
+  @Deprecated
+  @Nullable
+  public String getOperation() {
+    return getOperationName();
+  }
 
   @Nullable
-  public abstract String getMainIdentifier();
+  public abstract String getTarget();
+
+  /**
+   * @deprecated Use {@link #getTarget()} instead.
+   */
+  @Deprecated
+  @Nullable
+  public String getMainIdentifier() {
+    return getTarget();
+  }
 }


### PR DESCRIPTION
- Add getCollectionName() and getStoredProcedureName() to SqlStatementInfo
- Refactor MultiQuery to track collectionName and storedProcedureName separately
- Add DB_STORED_PROCEDURE_NAME attribute support
- Add three new tests for CALL statement instrumentation:
  - testStoredProcedureViaCallableStatement()
  - testStoredProcedureViaSqlStatement()
  - testStoredProcedureViaStatementExecuteQuery()