### PR TITLE
Module cleanup: batch (run 25476516454)

### DIFF
--- a/instrumentation/akka/akka-http-10.0/metadata.yaml
+++ b/instrumentation/akka/akka-http-10.0/metadata.yaml
@@ -13,24 +13,29 @@ features:
   - CONTEXT_PROPAGATION
 configurations:
   - name: otel.instrumentation.http.known-methods
+    declarative_name: java.common.http.known_methods
     description: >
       Configures the instrumentation to recognize an alternative set of HTTP request methods. All
       other methods will be treated as `_OTHER`.
     type: list
     default: "CONNECT,DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT,TRACE"
   - name: otel.instrumentation.http.client.capture-request-headers
+    declarative_name: general.http.client.request_captured_headers
     description: List of HTTP request headers to capture in HTTP client telemetry.
     type: list
     default: ""
   - name: otel.instrumentation.http.client.capture-response-headers
+    declarative_name: general.http.client.response_captured_headers
     description: List of HTTP response headers to capture in HTTP client telemetry.
     type: list
     default: ""
   - name: otel.instrumentation.common.peer-service-mapping
+    declarative_name: java.common.peer_service_mapping
     description: Used to specify a mapping from host names or IP addresses to peer services.
     type: map
     default: ""
   - name: otel.instrumentation.http.client.emit-experimental-telemetry
+    declarative_name: java.common.http.client.emit_experimental_telemetry/development
     description: >
       Enable the capture of experimental HTTP client telemetry. Adds the `http.request.body.size`
       and `http.response.body.size` attributes to spans, and records `http.client.request.size` and
@@ -38,14 +43,17 @@ configurations:
     type: boolean
     default: false
   - name: otel.instrumentation.http.server.capture-request-headers
+    declarative_name: general.http.server.request_captured_headers
     description: List of HTTP request headers to capture in HTTP server telemetry.
     type: list
     default: ""
   - name: otel.instrumentation.http.server.capture-response-headers
+    declarative_name: general.http.server.response_captured_headers
     description: List of HTTP response headers to capture in HTTP server telemetry.
     type: list
     default: ""
   - name: otel.instrumentation.http.server.emit-experimental-telemetry
+    declarative_name: java.common.http.server.emit_experimental_telemetry/development
     description: >
       Enable the capture of experimental HTTP server telemetry. Adds the `http.request.body.size`
       and `http.response.body.size` attributes to spans, and records `http.server.request.size` and
@@ -53,6 +61,7 @@ configurations:
     type: boolean
     default: false
   - name: otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters
+    declarative_name: general.sanitization.url.sensitive_query_parameters/development
     description: List of URL query parameter names whose values are redacted in URL attributes. See https://opentelemetry.io/docs/specs/semconv/http/http-spans.
     type: list
     default: "AWSAccessKeyId,Signature,sig,X-Goog-Signature"

--- a/instrumentation/alibaba-druid-1.0/library/src/main/java/io/opentelemetry/instrumentation/alibabadruid/v1_0/DruidTelemetry.java
+++ b/instrumentation/alibaba-druid-1.0/library/src/main/java/io/opentelemetry/instrumentation/alibabadruid/v1_0/DruidTelemetry.java
@@ -8,9 +8,11 @@ package io.opentelemetry.instrumentation.alibabadruid.v1_0;
 import com.alibaba.druid.pool.DruidDataSourceMBean;
 import io.opentelemetry.api.OpenTelemetry;
 
+/** Entrypoint for instrumenting Alibaba Druid database connection pools. */
 public final class DruidTelemetry {
   private final OpenTelemetry openTelemetry;
 
+  /** Returns a new {@link DruidTelemetry} configured with the given {@link OpenTelemetry}. */
   public static DruidTelemetry create(OpenTelemetry openTelemetry) {
     return new DruidTelemetry(openTelemetry);
   }
@@ -19,10 +21,12 @@ public final class DruidTelemetry {
     this.openTelemetry = openTelemetry;
   }
 
+  /** Start collecting metrics for given connection pool. */
   public void registerMetrics(DruidDataSourceMBean dataSource, String dataSourceName) {
     ConnectionPoolMetrics.registerMetrics(openTelemetry, dataSource, dataSourceName);
   }
 
+  /** Stop collecting metrics for given connection pool. */
   public void unregisterMetrics(DruidDataSourceMBean dataSource) {
     ConnectionPoolMetrics.unregisterMetrics(dataSource);
   }

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboHeadersSetter.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboHeadersSetter.java
@@ -15,7 +15,7 @@ final class DubboHeadersSetter implements TextMapSetter<DubboRequest> {
     if (request == null) {
       return;
     }
-    request.context().setAttachment(key, value);
+    request.getContext().setAttachment(key, value);
     request.invocation().setAttachment(key, value);
   }
 }

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboNetworkServerAttributesGetter.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboNetworkServerAttributesGetter.java
@@ -17,13 +17,13 @@ final class DubboNetworkServerAttributesGetter
   @Override
   public InetSocketAddress getNetworkLocalInetSocketAddress(
       DubboRequest request, @Nullable Result result) {
-    return request.localAddress();
+    return request.getLocalAddress();
   }
 
   @Override
   @Nullable
   public InetSocketAddress getNetworkPeerInetSocketAddress(
       DubboRequest request, @Nullable Result result) {
-    return request.remoteAddress();
+    return request.getRemoteAddress();
   }
 }

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboRequest.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboRequest.java
@@ -28,13 +28,47 @@ public abstract class DubboRequest {
 
   abstract RpcInvocation invocation();
 
-  public abstract RpcContext context();
+  public abstract RpcContext getContext();
 
-  public abstract URL url();
+  /**
+   * @deprecated Use {@link #getContext()} instead. Will be removed in a future release.
+   */
+  @Deprecated
+  public RpcContext context() {
+    return getContext();
+  }
+
+  public abstract URL getUrl();
+
+  /**
+   * @deprecated Use {@link #getUrl()} instead. Will be removed in a future release.
+   */
+  @Deprecated
+  public URL url() {
+    return getUrl();
+  }
 
   @Nullable
-  public abstract InetSocketAddress remoteAddress();
+  public abstract InetSocketAddress getRemoteAddress();
+
+  /**
+   * @deprecated Use {@link #getRemoteAddress()} instead. Will be removed in a future release.
+   */
+  @Deprecated
+  @Nullable
+  public InetSocketAddress remoteAddress() {
+    return getRemoteAddress();
+  }
 
   @Nullable
-  public abstract InetSocketAddress localAddress();
+  public abstract InetSocketAddress getLocalAddress();
+
+  /**
+   * @deprecated Use {@link #getLocalAddress()} instead. Will be removed in a future release.
+   */
+  @Deprecated
+  @Nullable
+  public InetSocketAddress localAddress() {
+    return getLocalAddress();
+  }
 }

--- a/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboClientNetworkAttributesGetter.java
+++ b/instrumentation/apache-dubbo-2.7/library-autoconfigure/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/internal/DubboClientNetworkAttributesGetter.java
@@ -22,18 +22,18 @@ public final class DubboClientNetworkAttributesGetter
   @Nullable
   @Override
   public String getServerAddress(DubboRequest request) {
-    return request.url().getHost();
+    return request.getUrl().getHost();
   }
 
   @Override
   public Integer getServerPort(DubboRequest request) {
-    return request.url().getPort();
+    return request.getUrl().getPort();
   }
 
   @Override
   @Nullable
   public InetSocketAddress getNetworkPeerInetSocketAddress(
       DubboRequest request, @Nullable Result response) {
-    return request.remoteAddress();
+    return request.getRemoteAddress();
   }
 }

--- a/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.java
+++ b/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTest.java
@@ -72,7 +72,7 @@ public abstract class AbstractDubboTest {
     System.clearProperty("dubbo.application.qos-enable");
   }
 
-  ReferenceConfig<HelloService> configureClient(int port) {
+  private static ReferenceConfig<HelloService> configureClient(int port) {
     ReferenceConfig<HelloService> reference = new ReferenceConfig<>();
     reference.setInterface(HelloService.class);
     reference.setGeneric("true");
@@ -80,7 +80,7 @@ public abstract class AbstractDubboTest {
     return reference;
   }
 
-  ServiceConfig<HelloServiceImpl> configureServer() {
+  private static ServiceConfig<HelloServiceImpl> configureServer() {
     RegistryConfig registerConfig = new RegistryConfig();
     registerConfig.setAddress("N/A");
     ServiceConfig<HelloServiceImpl> service = new ServiceConfig<>();
@@ -91,7 +91,8 @@ public abstract class AbstractDubboTest {
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
-  ReferenceConfig<GenericService> convertReference(ReferenceConfig<HelloService> config) {
+  private static ReferenceConfig<GenericService> convertReference(
+      ReferenceConfig<HelloService> config) {
     return (ReferenceConfig) config;
   }
 

--- a/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTraceChainTest.java
+++ b/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/AbstractDubboTraceChainTest.java
@@ -70,7 +70,7 @@ public abstract class AbstractDubboTraceChainTest {
 
   protected abstract boolean hasServicePeerName();
 
-  ReferenceConfig<HelloService> configureClient(int port) {
+  private static ReferenceConfig<HelloService> configureClient(int port) {
     ReferenceConfig<HelloService> reference = new ReferenceConfig<>();
     reference.setInterface(HelloService.class);
     reference.setGeneric("true");
@@ -78,7 +78,7 @@ public abstract class AbstractDubboTraceChainTest {
     return reference;
   }
 
-  ReferenceConfig<HelloService> configureLocalClient(int port) {
+  private static ReferenceConfig<HelloService> configureLocalClient(int port) {
     ReferenceConfig<HelloService> reference = new ReferenceConfig<>();
     reference.setInterface(HelloService.class);
     reference.setGeneric("true");
@@ -86,7 +86,7 @@ public abstract class AbstractDubboTraceChainTest {
     return reference;
   }
 
-  ReferenceConfig<MiddleService> configureMiddleClient(int port) {
+  private static ReferenceConfig<MiddleService> configureMiddleClient(int port) {
     ReferenceConfig<MiddleService> reference = new ReferenceConfig<>();
     reference.setInterface(MiddleService.class);
     reference.setGeneric("true");
@@ -94,7 +94,7 @@ public abstract class AbstractDubboTraceChainTest {
     return reference;
   }
 
-  ServiceConfig<HelloService> configureServer() {
+  private static ServiceConfig<HelloService> configureServer() {
     RegistryConfig registerConfig = new RegistryConfig();
     registerConfig.setAddress("N/A");
     ServiceConfig<HelloService> service = new ServiceConfig<>();
@@ -104,7 +104,7 @@ public abstract class AbstractDubboTraceChainTest {
     return service;
   }
 
-  ServiceConfig<MiddleService> configureMiddleServer(
+  private static ServiceConfig<MiddleService> configureMiddleServer(
       ReferenceConfig<HelloService> referenceConfig) {
     RegistryConfig registerConfig = new RegistryConfig();
     registerConfig.setAddress("N/A");
@@ -116,7 +116,8 @@ public abstract class AbstractDubboTraceChainTest {
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
-  ReferenceConfig<GenericService> convertReference(ReferenceConfig<MiddleService> config) {
+  private static ReferenceConfig<GenericService> convertReference(
+      ReferenceConfig<MiddleService> config) {
     return (ReferenceConfig) config;
   }
 

--- a/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTestUtil.java
+++ b/instrumentation/apache-dubbo-2.7/testing/src/main/java/io/opentelemetry/instrumentation/apachedubbo/v2_7/DubboTestUtil.java
@@ -12,7 +12,7 @@ import org.apache.dubbo.config.bootstrap.DubboBootstrap;
 /** compatible with dubbo3.x and dubbo 2.7 */
 class DubboTestUtil {
 
-  static Object newFrameworkModel() {
+  private static Object newFrameworkModel() {
     try {
       // only present in latest dep
       return Class.forName("org.apache.dubbo.rpc.model.FrameworkModel")

--- a/instrumentation/apache-elasticjob-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apacheelasticjob/v3_0/DataflowJobExecutorInstrumentation.java
+++ b/instrumentation/apache-elasticjob-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apacheelasticjob/v3_0/DataflowJobExecutorInstrumentation.java
@@ -58,7 +58,9 @@ class DataflowJobExecutorInstrumentation implements TypeInstrumentation {
     public static void onExit(
         @Advice.Enter @Nullable ElasticJobHelper.ElasticJobScope scope,
         @Advice.Thrown @Nullable Throwable throwable) {
-      helper().endSpan(scope, throwable);
+      if (scope != null) {
+        helper().endSpan(scope, throwable);
+      }
     }
   }
 }

--- a/instrumentation/apache-elasticjob-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apacheelasticjob/v3_0/ElasticJobHelper.java
+++ b/instrumentation/apache-elasticjob-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apacheelasticjob/v3_0/ElasticJobHelper.java
@@ -31,11 +31,9 @@ public class ElasticJobHelper {
     return new ElasticJobScope(request, context, context.makeCurrent());
   }
 
-  public void endSpan(@Nullable ElasticJobScope scope, @Nullable Throwable throwable) {
-    if (scope != null) {
-      scope.scope.close();
-      this.instrumenter.end(scope.context, scope.request, null, throwable);
-    }
+  public void endSpan(ElasticJobScope scope, @Nullable Throwable throwable) {
+    scope.scope.close();
+    this.instrumenter.end(scope.context, scope.request, null, throwable);
   }
 
   public static class ElasticJobScope {

--- a/instrumentation/apache-elasticjob-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apacheelasticjob/v3_0/HttpJobExecutorInstrumentation.java
+++ b/instrumentation/apache-elasticjob-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apacheelasticjob/v3_0/HttpJobExecutorInstrumentation.java
@@ -53,7 +53,9 @@ class HttpJobExecutorInstrumentation implements TypeInstrumentation {
     public static void onExit(
         @Advice.Enter @Nullable ElasticJobHelper.ElasticJobScope scope,
         @Advice.Thrown @Nullable Throwable throwable) {
-      helper().endSpan(scope, throwable);
+      if (scope != null) {
+        helper().endSpan(scope, throwable);
+      }
     }
   }
 }

--- a/instrumentation/apache-elasticjob-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apacheelasticjob/v3_0/ScriptJobExecutorInstrumentation.java
+++ b/instrumentation/apache-elasticjob-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apacheelasticjob/v3_0/ScriptJobExecutorInstrumentation.java
@@ -53,7 +53,9 @@ class ScriptJobExecutorInstrumentation implements TypeInstrumentation {
     public static void onExit(
         @Advice.Enter @Nullable ElasticJobHelper.ElasticJobScope scope,
         @Advice.Thrown @Nullable Throwable throwable) {
-      helper().endSpan(scope, throwable);
+      if (scope != null) {
+        helper().endSpan(scope, throwable);
+      }
     }
   }
 }

--- a/instrumentation/apache-elasticjob-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apacheelasticjob/v3_0/SimpleJobExecutorInstrumentation.java
+++ b/instrumentation/apache-elasticjob-3.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/apacheelasticjob/v3_0/SimpleJobExecutorInstrumentation.java
@@ -58,7 +58,9 @@ class SimpleJobExecutorInstrumentation implements TypeInstrumentation {
     public static void onExit(
         @Advice.Enter @Nullable ElasticJobHelper.ElasticJobScope scope,
         @Advice.Thrown @Nullable Throwable throwable) {
-      helper().endSpan(scope, throwable);
+      if (scope != null) {
+        helper().endSpan(scope, throwable);
+      }
     }
   }
 }


### PR DESCRIPTION
Automated module-cleanup batch.

## Modules in this batch

- `akka-http-10.0:javaagent`
- `alibaba-druid-1.0:library`
- `apache-dubbo-2.7:library-autoconfigure`
- `apache-dubbo-2.7:testing`
- `apache-elasticjob-3.0:javaagent`

---

## Cleanup for akka-http-10.0:javaagent

- Add declarative metadata names for Akka HTTP instrumentation configs

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


## Cleanup for alibaba-druid-1.0:library

- Add public API Javadocs to the Alibaba Druid telemetry entrypoint and metric registration methods

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


## Cleanup for apache-dubbo-2.7:library-autoconfigure

- Add getter-named DubboRequest accessors and deprecate the older property-style methods per public API naming policy
- Update internal library-autoconfigure call sites to use the getter-named accessors

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


## Cleanup for apache-dubbo-2.7:testing

- Tighten Dubbo testing helper methods to private static where they are only used internally

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


## Cleanup for apache-elasticjob-3.0:javaagent

- Move nullable ElasticJob advice scope handling into exit advice per javaagent advice pattern guidance

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>