### PR TITLE
Normalize internal OSGi and Kotlin extension package names

### DIFF
--- a/instrumentation/internal/internal-eclipse-osgi-3.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/eclipse/osgi/v3_6/EclipseOsgiInstrumentation.java
+++ b/instrumentation/internal/internal-eclipse-osgi-3.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/eclipse/osgi/v3_6/EclipseOsgiInstrumentation.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.internal.osgi;
+package io.opentelemetry.javaagent.instrumentation.internal.eclipse.osgi.v3_6;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.returns;

--- a/instrumentation/internal/internal-eclipse-osgi-3.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/eclipse/osgi/v3_6/EclipseOsgiInstrumentationModule.java
+++ b/instrumentation/internal/internal-eclipse-osgi-3.6/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/internal/eclipse/osgi/v3_6/EclipseOsgiInstrumentationModule.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.internal.osgi;
+package io.opentelemetry.javaagent.instrumentation.internal.eclipse.osgi.v3_6;
 
 import static java.util.Collections.singletonList;
 

--- a/instrumentation/opentelemetry-extension-kotlin-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetry/extension/kotlin/v1_0/ContextExtensionInstrumentation.java
+++ b/instrumentation/opentelemetry-extension-kotlin-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetry/extension/kotlin/v1_0/ContextExtensionInstrumentation.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.extensionkotlin.v1_0;
+package io.opentelemetry.javaagent.instrumentation.opentelemetry.extension.kotlin.v1_0;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;

--- a/instrumentation/opentelemetry-extension-kotlin-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetry/extension/kotlin/v1_0/ContextExtensionInstrumentationModule.java
+++ b/instrumentation/opentelemetry-extension-kotlin-1.0/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/opentelemetry/extension/kotlin/v1_0/ContextExtensionInstrumentationModule.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.extensionkotlin.v1_0;
+package io.opentelemetry.javaagent.instrumentation.opentelemetry.extension.kotlin.v1_0;
 
 import static java.util.Collections.singletonList;
 


### PR DESCRIPTION
## Summary
- rename the internal Eclipse OSGi javaagent package to match the module name
- rename the OpenTelemetry extension Kotlin javaagent package to match the module name

## Testing
- .github/scripts/check-package-names.sh
- ./gradlew :instrumentation:internal:internal-eclipse-osgi-3.6:javaagent:test :instrumentation:opentelemetry-extension-kotlin-1.0:javaagent:test

Note: this PR intentionally does not change .github/scripts/check-package-names.sh.