### PR TITLE
Normalize Spark javaagent package name

### DIFF
--- a/instrumentation/spark-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spark/v2_3/RoutesInstrumentation.java
+++ b/instrumentation/spark-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spark/v2_3/RoutesInstrumentation.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.sparkjava;
+package io.opentelemetry.javaagent.instrumentation.spark.v2_3;
 
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;

--- a/instrumentation/spark-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spark/v2_3/SparkInstrumentationModule.java
+++ b/instrumentation/spark-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spark/v2_3/SparkInstrumentationModule.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.sparkjava;
+package io.opentelemetry.javaagent.instrumentation.spark.v2_3;
 
 import static java.util.Collections.singletonList;
 

--- a/instrumentation/spark-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spark/v2_3/SparkRouteUpdater.java
+++ b/instrumentation/spark-2.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/spark/v2_3/SparkRouteUpdater.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.sparkjava;
+package io.opentelemetry.javaagent.instrumentation.spark.v2_3;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpServerRoute;

--- a/instrumentation/spark-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spark/v2_3/SparkJavaBasedTest.java
+++ b/instrumentation/spark-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spark/v2_3/SparkJavaBasedTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.sparkjava;
+package io.opentelemetry.javaagent.instrumentation.spark.v2_3;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.satisfies;

--- a/instrumentation/spark-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spark/v2_3/TestSparkJavaApplication.java
+++ b/instrumentation/spark-2.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/spark/v2_3/TestSparkJavaApplication.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.sparkjava;
+package io.opentelemetry.javaagent.instrumentation.spark.v2_3;
 
 import spark.Spark;
 


### PR DESCRIPTION
## Summary
- rename the Spark javaagent main and test packages from sparkjava to spark.v2_3

## Testing
- .github/scripts/check-package-names.sh
- ./gradlew :instrumentation:spark-2.3:javaagent:test

Note: this PR intentionally does not change .github/scripts/check-package-names.sh.