### PR TITLE
Normalize external annotations javaagent package name

### DIFF
--- a/instrumentation/external-annotations/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/external/annotations/IncludeTest.java
+++ b/instrumentation/external-annotations/javaagent-unit-tests/src/test/java/io/opentelemetry/javaagent/instrumentation/external/annotations/IncludeTest.java
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.extannotations;
+package io.opentelemetry.javaagent.instrumentation.external.annotations;
 
-import static io.opentelemetry.javaagent.instrumentation.extannotations.ExternalAnnotationInstrumentation.DEFAULT_ANNOTATIONS;
+import static io.opentelemetry.javaagent.instrumentation.external.annotations.ExternalAnnotationInstrumentation.DEFAULT_ANNOTATIONS;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;

--- a/instrumentation/external-annotations/javaagent/build.gradle.kts
+++ b/instrumentation/external-annotations/javaagent/build.gradle.kts
@@ -43,7 +43,7 @@ tasks {
       includeTestsMatching("ConfiguredTraceAnnotationsTest")
     }
     include("**/ConfiguredTraceAnnotationsTest.*")
-    jvmArgs("-Dotel.instrumentation.external-annotations.include=io.opentelemetry.javaagent.instrumentation.extannotations.OuterClass\$InterestingMethod")
+    jvmArgs("-Dotel.instrumentation.external-annotations.include=io.opentelemetry.javaagent.instrumentation.external.annotations.OuterClass\$InterestingMethod")
   }
 
   val testDeclarativeConfigInclude by registering(Test::class) {
@@ -68,7 +68,7 @@ tasks {
     }
     include("**/TracedMethodsExclusionTest.*")
     jvmArgs(
-      "-Dotel.instrumentation.external-annotations.exclude-methods=io.opentelemetry.javaagent.instrumentation.extannotations.TracedMethodsExclusionTest\$TestClass[excluded,annotatedButExcluded]"
+      "-Dotel.instrumentation.external-annotations.exclude-methods=io.opentelemetry.javaagent.instrumentation.external.annotations.TracedMethodsExclusionTest\$TestClass[excluded,annotatedButExcluded]"
     )
   }
 

--- a/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/external/annotations/ExternalAnnotationInstrumentation.java
+++ b/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/external/annotations/ExternalAnnotationInstrumentation.java
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.extannotations;
+package io.opentelemetry.javaagent.instrumentation.external.annotations;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
-import static io.opentelemetry.javaagent.instrumentation.extannotations.ExternalAnnotationSingletons.instrumenter;
+import static io.opentelemetry.javaagent.instrumentation.external.annotations.ExternalAnnotationSingletons.instrumenter;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.logging.Level.WARNING;

--- a/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/external/annotations/ExternalAnnotationInstrumentationModule.java
+++ b/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/external/annotations/ExternalAnnotationInstrumentationModule.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.extannotations;
+package io.opentelemetry.javaagent.instrumentation.external.annotations;
 
 import static java.util.Collections.singletonList;
 

--- a/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/external/annotations/ExternalAnnotationSingletons.java
+++ b/instrumentation/external-annotations/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/external/annotations/ExternalAnnotationSingletons.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.extannotations;
+package io.opentelemetry.javaagent.instrumentation.external.annotations;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.code.CodeAttributesExtractor;

--- a/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/external/annotations/ConfiguredTraceAnnotationsTest.java
+++ b/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/external/annotations/ConfiguredTraceAnnotationsTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.extannotations;
+package io.opentelemetry.javaagent.instrumentation.external.annotations;
 
 import static io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeStabilityUtil.codeFunctionAssertions;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/external/annotations/OuterClass.java
+++ b/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/external/annotations/OuterClass.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.extannotations;
+package io.opentelemetry.javaagent.instrumentation.external.annotations;
 
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;

--- a/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/external/annotations/SayTracedHello.java
+++ b/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/external/annotations/SayTracedHello.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.extannotations;
+package io.opentelemetry.javaagent.instrumentation.external.annotations;
 
 import io.opentelemetry.api.trace.Span;
 import java.util.concurrent.Callable;

--- a/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/external/annotations/TraceAnnotationsTest.java
+++ b/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/external/annotations/TraceAnnotationsTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.extannotations;
+package io.opentelemetry.javaagent.instrumentation.external.annotations;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.testing.junit.code.SemconvCodeStabilityUtil.codeFunctionAssertions;

--- a/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/external/annotations/TraceProvidersTest.java
+++ b/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/external/annotations/TraceProvidersTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.extannotations;
+package io.opentelemetry.javaagent.instrumentation.external.annotations;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;

--- a/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/external/annotations/TracedMethodsExclusionTest.java
+++ b/instrumentation/external-annotations/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/external/annotations/TracedMethodsExclusionTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.extannotations;
+package io.opentelemetry.javaagent.instrumentation.external.annotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/instrumentation/external-annotations/javaagent/src/test/resources/declarative-config-exclude-methods.yaml
+++ b/instrumentation/external-annotations/javaagent/src/test/resources/declarative-config-exclude-methods.yaml
@@ -3,7 +3,7 @@ instrumentation/development:
   java:
     external_annotations:
       exclude_methods:
-        - class: io.opentelemetry.javaagent.instrumentation.extannotations.TracedMethodsExclusionTest$TestClass
+        - class: io.opentelemetry.javaagent.instrumentation.external.annotations.TracedMethodsExclusionTest$TestClass
           methods:
             - excluded
             - annotatedButExcluded

--- a/instrumentation/external-annotations/javaagent/src/test/resources/declarative-config-include.yaml
+++ b/instrumentation/external-annotations/javaagent/src/test/resources/declarative-config-include.yaml
@@ -3,4 +3,4 @@ instrumentation/development:
   java:
     external_annotations:
       include:
-        - io.opentelemetry.javaagent.instrumentation.extannotations.OuterClass$InterestingMethod
+        - io.opentelemetry.javaagent.instrumentation.external.annotations.OuterClass$InterestingMethod


### PR DESCRIPTION
## Summary
- rename the external annotations javaagent packages from extannotations to external.annotations
- update test config strings that refer to the renamed test classes

## Testing
- .github/scripts/check-package-names.sh
- ./gradlew :instrumentation:external-annotations:javaagent:test :instrumentation:external-annotations:javaagent-unit-tests:test

Note: this PR intentionally does not change .github/scripts/check-package-names.sh.