### PR TITLE
Normalize Hibernate procedure-call javaagent package name

### DIFF
--- a/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/procedure/call/v4_3/Hibernate43Singletons.java
+++ b/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/procedure/call/v4_3/Hibernate43Singletons.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.hibernate.v4_3;
+package io.opentelemetry.javaagent.instrumentation.hibernate.procedure.call.v4_3;
 
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.util.VirtualField;

--- a/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/procedure/call/v4_3/HibernateInstrumentationModule.java
+++ b/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/procedure/call/v4_3/HibernateInstrumentationModule.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.hibernate.v4_3;
+package io.opentelemetry.javaagent.instrumentation.hibernate.procedure.call.v4_3;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;

--- a/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/procedure/call/v4_3/ProcedureCallInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/procedure/call/v4_3/ProcedureCallInstrumentation.java
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.hibernate.v4_3;
+package io.opentelemetry.javaagent.instrumentation.hibernate.procedure.call.v4_3;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
-import static io.opentelemetry.javaagent.instrumentation.hibernate.v4_3.Hibernate43Singletons.PROCEDURE_CALL_SESSION_INFO;
-import static io.opentelemetry.javaagent.instrumentation.hibernate.v4_3.Hibernate43Singletons.instrumenter;
+import static io.opentelemetry.javaagent.instrumentation.hibernate.procedure.call.v4_3.Hibernate43Singletons.PROCEDURE_CALL_SESSION_INFO;
+import static io.opentelemetry.javaagent.instrumentation.hibernate.procedure.call.v4_3.Hibernate43Singletons.instrumenter;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import io.opentelemetry.context.Context;

--- a/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/procedure/call/v4_3/SessionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/hibernate/procedure/call/v4_3/SessionInstrumentation.java
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.hibernate.v4_3;
+package io.opentelemetry.javaagent.instrumentation.hibernate.procedure.call.v4_3;
 
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.implementsInterface;
-import static io.opentelemetry.javaagent.instrumentation.hibernate.v4_3.Hibernate43Singletons.PROCEDURE_CALL_SESSION_INFO;
-import static io.opentelemetry.javaagent.instrumentation.hibernate.v4_3.Hibernate43Singletons.SHARED_SESSION_CONTRACT_SESSION_INFO;
+import static io.opentelemetry.javaagent.instrumentation.hibernate.procedure.call.v4_3.Hibernate43Singletons.PROCEDURE_CALL_SESSION_INFO;
+import static io.opentelemetry.javaagent.instrumentation.hibernate.procedure.call.v4_3.Hibernate43Singletons.SHARED_SESSION_CONTRACT_SESSION_INFO;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
 

--- a/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/procedure/call/v4_3/ProcedureCallTest.java
+++ b/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/procedure/call/v4_3/ProcedureCallTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.hibernate.v4_3;
+package io.opentelemetry.javaagent.instrumentation.hibernate.procedure.call.v4_3;
 
 import static io.opentelemetry.api.trace.SpanKind.CLIENT;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;

--- a/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/procedure/call/v4_3/Value.java
+++ b/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/java/io/opentelemetry/javaagent/instrumentation/hibernate/procedure/call/v4_3/Value.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.javaagent.instrumentation.hibernate.v4_3;
+package io.opentelemetry.javaagent.instrumentation.hibernate.procedure.call.v4_3;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;

--- a/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/resources/hibernate.cfg.xml
+++ b/instrumentation/hibernate/hibernate-procedure-call-4.3/javaagent/src/test/resources/hibernate.cfg.xml
@@ -17,7 +17,7 @@
     <property name="hibernate.hbm2ddl.auto">create</property>
 
     <!-- Objects -->
-    <mapping class="io.opentelemetry.javaagent.instrumentation.hibernate.v4_3.Value"/>
+    <mapping class="io.opentelemetry.javaagent.instrumentation.hibernate.procedure.call.v4_3.Value"/>
 
   </session-factory>
 


### PR DESCRIPTION
## Summary
- rename the Hibernate procedure-call javaagent main and test packages to hibernate.procedure.call.v4_3
- update the Hibernate test mapping string for the renamed test entity

## Testing
- .github/scripts/check-package-names.sh
- ./gradlew :instrumentation:hibernate:hibernate-procedure-call-4.3:javaagent:test

Note: this PR intentionally does not change .github/scripts/check-package-names.sh.